### PR TITLE
Fix for "not in the 'Connected' State." exception. Added Dev NuGet dependencies instead of Trial.

### DIFF
--- a/BlazorGridAndReportViewer/BlazorGridAndReport/BlazorGridAndReport.csproj
+++ b/BlazorGridAndReportViewer/BlazorGridAndReport/BlazorGridAndReport.csproj
@@ -9,11 +9,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.0" />
-    <PackageReference Include="Telerik.Reporting.OpenXmlRendering.Trial" Version="*" />
-    <PackageReference Include="Telerik.Reporting.Services.AspNetCore.Trial" Version="*" />
-    <PackageReference Include="Telerik.Reporting.WebServiceDataSource.Trial" Version="*" />
-    <PackageReference Include="Telerik.ReportViewer.Blazor.Trial" Version="*" />
-    <PackageReference Include="Telerik.UI.for.Blazor.Trial" Version="4.0.0" />
+    <PackageReference Include="Telerik.Reporting.OpenXmlRendering" Version="*" />
+    <PackageReference Include="Telerik.Reporting.Services.AspNetCore" Version="*" />
+    <PackageReference Include="Telerik.Reporting.WebServiceDataSource" Version="*" />
+    <PackageReference Include="Telerik.ReportViewer.Blazor" Version="*" />
+    <PackageReference Include="Telerik.UI.for.Blazor" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BlazorGridAndReportViewer/BlazorGridAndReport/Pages/_Host.cshtml
+++ b/BlazorGridAndReportViewer/BlazorGridAndReport/Pages/_Host.cshtml
@@ -16,9 +16,9 @@
     <link href="css/site.css" rel="stylesheet" />
 
     @* For Blazor UI *@
-    <script src="_content/Telerik.ReportViewer.Blazor.Trial/interop.js" defer></script>
-    <script src="_content/Telerik.UI.for.Blazor.Trial/js/telerik-blazor.js" defer></script>
-    <link rel="stylesheet" href="_content/Telerik.UI.for.Blazor.Trial/css/kendo-theme-default/all.css" />
+    <script src="_content/Telerik.UI.for.Blazor/js/telerik-blazor.js" defer></script>
+    <script src="_content/Telerik.ReportViewer.Blazor/interop.js" defer></script>
+    <link rel="stylesheet" href="_content/Telerik.UI.for.Blazor/css/kendo-theme-default/all.css" />
 
     @* For Reporting *@
     <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
@@ -51,6 +51,11 @@
         <a class="dismiss">🗙</a>
     </div>
 
-    <script src="_framework/blazor.server.js"></script>
+    <script src="_framework/blazor.server.js" autostart="false"></script>
+    <script>
+      document.addEventListener("DOMContentLoaded", function() {
+        Blazor.start();
+      });
+    </script>
 </body>
 </html>

--- a/BlazorGridAndReportViewer/README.md
+++ b/BlazorGridAndReportViewer/README.md
@@ -5,12 +5,16 @@
 
 This project is based on the [Blazor DataGrid Meets Blazor Report Viewer](https://www.telerik.com/blogs/blazor-datagrid-meets-blazor-report-viewer) blog post and it demonstrates
 the integration between [Telerik Reporting](https://www.telerik.com/products/reporting.aspx) and [Telerik UI for Blazor](https://www.telerik.com/blazor-ui).
+The project is also used in the [Telerik UI for Blazor live demos](https://demos.telerik.com/blazor-ui/reporting-integration/grid-report).
 
 
 
 
 ### Instructions
 
-Thr projct uses Trial packages, if you want to use the licensed, you need to make the following changes in the project:
-- BlazorGridAndReport.csproj - remove ".Trial" from the Telerik NuGet packages;
-- _Host.cshtml - remove ".Trial" from the references in the file
+This project uses Dev (licensed) packages, if you want to use the Trial ones, you need to make the following changes:
+- BlazorGridAndReport.csproj - add ".Trial" to the Telerik NuGet packages;
+- _Host.cshtml - Add ".Trial" to the Telerik references in the file, example:
+ <script src="_content/Telerik.UI.for.Blazor.Trial/js/telerik-blazor.js" defer></script>
+ <link rel="stylesheet" href="_content/Telerik.UI.for.Blazor.Trial/css/kendo-theme-default/all.css" />
+ <script src="_content/Telerik.ReportViewer.Blazor.Trial/interop.js" defer></script>


### PR DESCRIPTION
Fix for "Cannot send data if the connection is not in the 'Connected' State" and Microsoft.JSInterop.JSException: Could not find 'TelerikBlazor.initMediaQuery' ('TelerikBlazor' was undefined). Both are reproducible on live demo https://demos.telerik.com/blazor-ui/reporting-integration/grid-report

https://gyazo.com/7c72c9b98937ab130d3baebe2b1e5cfe
https://gyazo.com/64786125db57e8e416e33abd22029249