### PR TITLE
chore: update wrd sql storage example for report templates

### DIFF
--- a/SqlDefinitionStorageExample/CustomDefinitionStorage.cs
+++ b/SqlDefinitionStorageExample/CustomDefinitionStorage.cs
@@ -7,12 +7,8 @@ using System;
 
 namespace SqlDefinitionStorageExample
 {
-    public class CustomDefinitionStorage : ResourceStorageBase, IDefinitionStorage, IAssetsStorage
+    public class CustomDefinitionStorage(SqlDefinitionStorageContext dbContext, string rootFolder = "Reports") : ResourceStorageBase(dbContext, rootFolder), IDefinitionStorage, IAssetsStorage
     {
-        public CustomDefinitionStorage(SqlDefinitionStorageContext dbContext, string rootFolder = "Reports" ) : base(dbContext, rootFolder)
-        {
-        }
-
         public new Task<ResourceFolderModel> CreateFolderAsync(CreateFolderModel model)
         {
             if(model.Name == Root)
@@ -49,7 +45,22 @@ namespace SqlDefinitionStorageExample
         Task<ResourceFileModel> IAssetsStorage.RenameAsync(RenameResourceModel model) => RenameAsync(model);
 
         Task<ResourceFolderModel> IAssetsStorage.RenameFolderAsync(RenameFolderModel model) => RenameFolderAsync(model);
-        
+
+        protected virtual Task<ResourceFileModel> SaveAsync<TDefinitionNotFoundException>(SaveResourceModel model, byte[] resource) where TDefinitionNotFoundException : Exception
+        {
+            return Task.FromResult(WrapException<ResourceFileModel, TDefinitionNotFoundException, ResourceNotFoundException>(() => SaveAsync(model, resource).ToResult()));
+        }
+        protected virtual Task<ResourceFileModel> RenameAsync<TInvalidDefinitionNameException>(RenameResourceModel model) where TInvalidDefinitionNameException : Exception
+        {
+            return Task.FromResult(WrapException<ResourceFileModel, TInvalidDefinitionNameException, InvalidResourceNameException>(() => RenameAsync(model).ToResult()));
+        }
+
+        protected virtual Task<byte[]> GetAsync<TDefinitionNotFoundException>(string resourceName) where TDefinitionNotFoundException : Exception
+        {
+            return Task.FromResult(WrapException<byte[], TDefinitionNotFoundException, ResourceNotFoundException>(() => GetAsync(PrepareResourceUri(resourceName)).ToResult()));
+        }
+
+
         protected string PrepareResourceUri(string uri)
         {
             if (string.IsNullOrEmpty(uri))
@@ -61,6 +72,18 @@ namespace SqlDefinitionStorageExample
             uri = uri.Contains($"{Root}\\") ? uri : $"{Root}\\{uri}";
 
             return uri;
+        }
+
+        protected TResult WrapException<TResult, TDefinitionException, TResourceException>(Func<TResult> callback) where TDefinitionException : Exception where TResourceException : Exception
+        {
+            try
+            {
+                return callback();
+            }
+            catch (TResourceException ex)
+            {
+                throw (TDefinitionException)Activator.CreateInstance(typeof(TDefinitionException), ex.Message, ex);
+            }
         }
     }
 }

--- a/SqlDefinitionStorageExample/CustomTemplateDefinitionStorage.cs
+++ b/SqlDefinitionStorageExample/CustomTemplateDefinitionStorage.cs
@@ -1,0 +1,24 @@
+﻿using SqlDefinitionStorageExample.EFCore;
+using System.Threading.Tasks;
+using Telerik.WebReportDesigner.Services;
+using Telerik.WebReportDesigner.Services.Models;
+
+namespace SqlDefinitionStorageExample
+{
+    public class CustomTemplateDefinitionStorage(SqlDefinitionStorageContext dbContext, string rootFolder = "Templates") : CustomDefinitionStorage(dbContext, rootFolder), IDefinitionStorage
+    {
+        public new Task<byte[]> GetAsync(string resourceName)
+        {
+            return base.GetAsync<ReportNotFoundException>(resourceName);
+        }
+        public new Task<ResourceFileModel> RenameAsync(RenameResourceModel model)
+        {
+            return base.RenameAsync<InvalidReportNameException>(model);
+        }
+
+        public new Task<ResourceFileModel> SaveAsync(SaveResourceModel model, byte[] resource)
+        {
+            return base.SaveAsync<ReportNotFoundException>(model, resource);
+        }
+    }
+}

--- a/SqlDefinitionStorageExample/EFCore/SqlDefinitionStorageContext.cs
+++ b/SqlDefinitionStorageExample/EFCore/SqlDefinitionStorageContext.cs
@@ -1,17 +1,16 @@
 ﻿using SqlDefinitionStorageExample.EFCore.Models;
 using Microsoft.EntityFrameworkCore;
 using System.Threading.Tasks;
+using System;
 
 namespace SqlDefinitionStorageExample.EFCore
 {
-    public class SqlDefinitionStorageContext : DbContext
+    public class SqlDefinitionStorageContext(DbContextOptions<SqlDefinitionStorageContext> options) : DbContext(options)
     {
 
         public DbSet<Resource> Resources { get; set; }
 
         public DbSet<ResourceFolder> ResourceFolders { get; set; }
-
-        public SqlDefinitionStorageContext(DbContextOptions<SqlDefinitionStorageContext> options) : base(options) { }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
@@ -28,11 +27,13 @@ namespace SqlDefinitionStorageExample.EFCore
         {
             IsDisposed = true;
             base.Dispose();
+            GC.SuppressFinalize(this);
         }
 
         public override ValueTask DisposeAsync()
         {
             IsDisposed = true;
+            GC.SuppressFinalize(this);
             return base.DisposeAsync();
         }
     }

--- a/SqlDefinitionStorageExample/Program.cs
+++ b/SqlDefinitionStorageExample/Program.cs
@@ -16,11 +16,11 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 builder.Services.AddControllers();
-builder.Services.AddRazorPages()
-                .AddNewtonsoftJson();
+builder.Services.AddRazorPages();
 
 builder.Services.AddDbContext<SqlDefinitionStorageContext>();
-builder.Services.AddScoped<IDefinitionStorage, CustomDefinitionStorage>();
+builder.Services.AddScoped<CustomDefinitionStorage>();
+builder.Services.AddScoped<CustomTemplateDefinitionStorage>();
 builder.Services.AddScoped<ISharedDataSourceStorage, CustomSharedDataSourceStorage>();
 builder.Services.AddScoped<IResourceStorage, CustomResourceStorage>();
 builder.Services.AddScoped<ISharedDataSourceStorage, CustomSharedDataSourceStorage>();
@@ -41,7 +41,8 @@ builder.Services.TryAddScoped<IReportServiceConfiguration>(sp =>
 // Configure dependencies for ReportDesignerController.
 builder.Services.TryAddScoped<IReportDesignerServiceConfiguration>(sp => new ReportDesignerServiceConfiguration
 {
-    DefinitionStorage = sp.GetRequiredService<IDefinitionStorage>(),
+    DefinitionStorage = sp.GetRequiredService<CustomDefinitionStorage>(),
+    TemplateDefinitionStorage = sp.GetRequiredService<CustomTemplateDefinitionStorage>(),
     ResourceStorage = sp.GetRequiredService<IResourceStorage>(),
     SharedDataSourceStorage = sp.GetRequiredService<ISharedDataSourceStorage>(),
     SettingsStorage = new FileSettingsStorage(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Telerik Reporting"))
@@ -65,10 +66,7 @@ using (var serviceScope = app.Services.CreateScope())
 
 app.UseStaticFiles();
 app.UseRouting();
-app.UseEndpoints(endpoints =>
-{
-    endpoints.MapControllers();
-});
+app.MapControllers();
 
 // Add initial data to database
 app.Seed();

--- a/SqlDefinitionStorageExample/ReportsInitializer.cs
+++ b/SqlDefinitionStorageExample/ReportsInitializer.cs
@@ -22,10 +22,12 @@ namespace SqlDefinitionStorageExample
                     var sampleReport = CreateResource("SampleReport.trdp", "Reports");
                     var reportsFolder = CreateFolderModel("Reports", string.Empty);
                     var resourcesFolder = CreateFolderModel("Resources", string.Empty);
+                    var templatesFolder = CreateFolderModel("Templates", string.Empty);
 
                     context.Resources.Add(sampleReport.ToDbResourceModel(System.IO.File.ReadAllBytes("SampleReport.trdp")));
                     context.ResourceFolders.Add(reportsFolder.ToDbResourceFolderModel());
                     context.ResourceFolders.Add(resourcesFolder.ToDbResourceFolderModel());
+                    context.ResourceFolders.Add(templatesFolder.ToDbResourceFolderModel());
 
                     context.SaveChanges();
                 }

--- a/SqlDefinitionStorageExample/SqlDefinitionStorageExample.csproj
+++ b/SqlDefinitionStorageExample/SqlDefinitionStorageExample.csproj
@@ -17,9 +17,7 @@
   <ItemGroup>
     <!--The following lines are replaced with package refs during the product build-->
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
-    <PackageReference Include="Telerik.Reporting.OpenXmlRendering" Version="18.2.24.924" />
-    <PackageReference Include="Telerik.Reporting.Services.AspNetCore" Version="18.2.24.924" />
-    <PackageReference Include="Telerik.WebReportDesigner.Services" Version="18.2.24.924" />
+    <PackageReference Include="Telerik.WebReportDesigner.Services" Version="20.0.26.304" />
   </ItemGroup>
   <ItemGroup>
     <None Update="SampleReport.trdp">

--- a/SqlDefinitionStorageExample/wwwroot/index.html
+++ b/SqlDefinitionStorageExample/wwwroot/index.html
@@ -16,11 +16,11 @@
         loading...
     </div>
 
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-    <script src="https://reporting.cdn.telerik.com/18.2.24.924/js/webReportDesigner.kendo.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
+    <script src="https://reporting.cdn.telerik.com/20.0.26.304/js/webReportDesigner.kendo.min.js"></script>
 
     <script src="/api/reports/resources/js/telerikReportViewer"></script>
-    <script src="/api/reportdesigner/designerresources/js/webReportDesigner-18.2.24.924.min.js/"></script>
+    <script src="/api/reportdesigner/designerresources/js/webReportDesigner"></script>
 
     <script type="text/javascript">
         $(document).ready(function () {
@@ -33,19 +33,6 @@
                 },
                 serviceUrl: "api/reportdesigner/",
                 report: "SampleReport.trdp",
-                //report: "Product Catalog.trdp",
-
-                // Example of passing parameters to the embedded Report Viewer used when previewing documents.
-                // The example below demonstrates the currently available options.
-                // reportViewerOptions: {
-                //    scaleMode: telerikReportViewer.ScaleModes.SPECIFIC,
-                //    scale: 1.0,
-                //    templateUrl: "api/reportdesigner/resources/templates/telerikReportViewerTemplate.html/",
-                //    viewMode: telerikReportViewer.ViewModes.INTERACTIVE,
-                //    pageMode: telerikReportViewer.PageModes.CONTINUOUS_SCROLL
-                //    // Further explanation about how these options effect the Report Viewer can be found at:
-                //    // https://docs.telerik.com/reporting/embedding-reports/display-reports-in-applications/web-application/html5-report-viewer/api-reference/report-viewer-initialization
-                // }
             }).data("telerik_WebDesigner");
         });
     </script>


### PR DESCRIPTION
Updated the wrd sql storage example to use the latest reporting and support the new report templates in wrd